### PR TITLE
fix: Fixed typo in route format

### DIFF
--- a/client/pyrostorage/client.py
+++ b/client/pyrostorage/client.py
@@ -29,8 +29,8 @@ ROUTES: Dict[str, str] = {
     # ANNOTATIONS
     #################
     "create-annotation": "/annotations",
-    "upload-annotation": "/annotations/{media_id}/upload",
-    "get-annotation-url": "/annotations/{media_id}/url",
+    "upload-annotation": "/annotations/{annotation_id}/upload",
+    "get-annotation-url": "/annotations/{annotation_id}/url",
 }
 
 


### PR DESCRIPTION
As pointed out by @pechouc, this PR fixes the f string of the routes for annotation upload and URL retrieval.

Any feedback is welcome!