### PR TITLE
fix: Fixes Sentry quotas by removing trace samples

### DIFF
--- a/src/app/main.py
+++ b/src/app/main.py
@@ -26,7 +26,7 @@ if isinstance(cfg.SENTRY_DSN, str):
         release=cfg.VERSION,
         server_name=cfg.SERVER_NAME,
         environment="production" if isinstance(cfg.SERVER_NAME, str) else None,
-        traces_sample_rate=0.,
+        traces_sample_rate=0.0,
     )
     logger.info(f"Sentry middleware enabled on server {cfg.SERVER_NAME}")
 

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -26,7 +26,7 @@ if isinstance(cfg.SENTRY_DSN, str):
         release=cfg.VERSION,
         server_name=cfg.SERVER_NAME,
         environment="production" if isinstance(cfg.SERVER_NAME, str) else None,
-        traces_sample_rate=1.0,
+        traces_sample_rate=0.,
     )
     logger.info(f"Sentry middleware enabled on server {cfg.SERVER_NAME}")
 


### PR DESCRIPTION
This PR removes the trace sample logging via Sentry (not the error catching, but logging all the interactions  which burst through our quotas)